### PR TITLE
Fixes: Model Core

### DIFF
--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -3,10 +3,10 @@ sourceRepo = "git@github.com:OpenCannabis/Specification.git"
 sourceBranch = "master"
 
 protocolRepo = "git@github.com:OpenCannabis/Protocol.git"
-protocolBranch = "master"
+protocolBranch = "ocp/upstream"
 
 pythonRepo = "git@github.com:OpenCannabis/Python.git"
-pythonBranch = "master"
+pythonBranch = "ocp/upstream"
 
 core.workflow(
     name = "protocol",
@@ -32,6 +32,16 @@ core.workflow(
     authoring = authoring.pass_thru(
         "Cookiebot <techteam+github@cookiescalifornia.com>"),
     transformations = [
+        core.replace(
+            before = "@gust//gust/core:datamodel",
+            after = "//opencannabis/core:Datamodel",
+            paths = glob(["**/*.bazel", "**/BUILD*"]),
+        ),
+        core.replace(
+            before = "gust/core/datamodel.proto",
+            after = "opencannabis/core/Datamodel.proto",
+            paths = glob(["**/*.proto"]),
+        ),
         core.replace(
             before = "${x}",
             after = "",

--- a/opencannabis/base/BUILD.bazel
+++ b/opencannabis/base/BUILD.bazel
@@ -25,7 +25,7 @@ proto(
     deps = [
         ":ProductKind",
         "//opencannabis/content:Name",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/base/ProductKey.proto
+++ b/opencannabis/base/ProductKey.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.base";
 option java_multiple_files = false;
 option java_outer_classname = "BaseProductKey";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/content/Name.proto";
 import "opencannabis/base/ProductKind.proto";

--- a/opencannabis/commerce/BUILD.bazel
+++ b/opencannabis/commerce/BUILD.bazel
@@ -14,7 +14,7 @@ proto(
     srcs = ["Customer.proto"],
     deps = [
         "//opencannabis/person:Person",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -22,7 +22,7 @@ proto(
     srcs = ["Delivery.proto"],
     deps = [
         "//opencannabis/geo:Address",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -48,7 +48,7 @@ proto(
         ":Customer",
         "//opencannabis/commerce/payments:Payment",
         "//opencannabis/temporal:Instant",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -58,7 +58,7 @@ proto(
         ":Item",
         ":Currency",
         ":Discounts",
-        "//opencannabis/core:Datamodel",
+        "@gust//gust/core:datamodel",
         "//opencannabis/accounting:Taxes",
         "//opencannabis/crypto:Signature",
         "//opencannabis/commerce/payments:Payment",

--- a/opencannabis/commerce/Customer.proto
+++ b/opencannabis/commerce/Customer.proto
@@ -13,7 +13,7 @@ option java_package = "io.opencannabis.schema.commerce";
 option java_multiple_files = false;
 option java_outer_classname = "OrderCustomer";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/person/Person.proto";
 
 

--- a/opencannabis/commerce/Delivery.proto
+++ b/opencannabis/commerce/Delivery.proto
@@ -13,7 +13,7 @@ option java_package = "io.opencannabis.schema.commerce";
 option java_multiple_files = false;
 option java_outer_classname = "OrderDelivery";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/geo/Address.proto";
 

--- a/opencannabis/commerce/Order.proto
+++ b/opencannabis/commerce/Order.proto
@@ -13,7 +13,7 @@ option java_package = "io.opencannabis.schema.commerce";
 option java_multiple_files = false;
 option java_outer_classname = "CommercialOrder";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/commerce/Item.proto";
 import "opencannabis/commerce/Delivery.proto";

--- a/opencannabis/commerce/Purchase.proto
+++ b/opencannabis/commerce/Purchase.proto
@@ -13,7 +13,7 @@ option java_package = "io.opencannabis.schema.commerce";
 option java_multiple_files = false;
 option java_outer_classname = "CommercialPurchase";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/accounting/Taxes.proto";
 

--- a/opencannabis/contact/BUILD.bazel
+++ b/opencannabis/contact/BUILD.bazel
@@ -7,19 +7,19 @@ load("//defs:proto.bzl", "proto", "module")
 proto(
     name = "EmailAddress",
     srcs = ["EmailAddress.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "PhoneNumber",
     srcs = ["PhoneNumber.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "Website",
     srcs = ["Website.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -30,7 +30,7 @@ proto(
         ":EmailAddress",
         ":Website",
         "//opencannabis/geo:Location",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/contact/ContactInfo.proto
+++ b/opencannabis/contact/ContactInfo.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.contact";
 option java_multiple_files = false;
 option java_outer_classname = "GenericContact";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/geo/Location.proto";
 import "opencannabis/contact/PhoneNumber.proto";

--- a/opencannabis/contact/EmailAddress.proto
+++ b/opencannabis/contact/EmailAddress.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.contact";
 option java_multiple_files = false;
 option java_outer_classname = "ContactEmail";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Specifies information about an electronic mail (email) address, and optionally, its validation status.

--- a/opencannabis/contact/PhoneNumber.proto
+++ b/opencannabis/contact/PhoneNumber.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.contact";
 option java_multiple_files = false;
 option java_outer_classname = "ContactPhone";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Payload that specifies a phone number, and any additional information to be carried with it (including verification

--- a/opencannabis/contact/Website.proto
+++ b/opencannabis/contact/Website.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.contact";
 option java_multiple_files = false;
 option java_outer_classname = "ContactWebsite";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Specifies a structure that describes a URI/website, and related information.

--- a/opencannabis/content/BUILD.bazel
+++ b/opencannabis/content/BUILD.bazel
@@ -18,7 +18,7 @@ proto(
     name = "Content",
     srcs = ["Content.proto"],
     deps = [
-        "//opencannabis/core:Datamodel",
+        "@gust//gust/core:datamodel",
         "//opencannabis/base:Language",
         "//opencannabis/base:Compression"],
 )
@@ -61,7 +61,7 @@ proto(
         "//opencannabis/temporal:Instant",
         "//opencannabis/structs/pricing:PricingDescriptor",
         "//opencannabis/structs/labtesting:TestResults",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/content/ProductContent.proto
+++ b/opencannabis/content/ProductContent.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.content";
 option java_multiple_files = false;
 option java_outer_classname = "AttachedContent";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/content/Name.proto";
 import "opencannabis/content/Content.proto";

--- a/opencannabis/device/BUILD.bazel
+++ b/opencannabis/device/BUILD.bazel
@@ -7,7 +7,7 @@ load("//defs:proto.bzl", "proto", "module")
 proto(
     name = "Device",
     srcs = ["Device.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/device/Device.proto
+++ b/opencannabis/device/Device.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.device";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Enumerates major types of devices that might be encountered, including desktops, phones, tablets, TVs, and browsers.

--- a/opencannabis/geo/Address.proto
+++ b/opencannabis/geo/Address.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.geo";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Specifies a standard postal address, with two address lines, and space for a municipality ('city'), provincial

--- a/opencannabis/geo/BUILD.bazel
+++ b/opencannabis/geo/BUILD.bazel
@@ -7,19 +7,19 @@ load("//defs:proto.bzl", "proto", "module")
 proto(
     name = "Address",
     srcs = ["Address.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "Country",
     srcs = ["Country.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "Distance",
     srcs = ["Distance.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -27,7 +27,7 @@ proto(
     srcs = ["Geohash.proto"],
     deps = [
         ":Distance",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -35,7 +35,7 @@ proto(
     srcs = ["Point.proto"],
     deps = [
         ":Distance",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -46,7 +46,7 @@ proto(
         ":Point",
         ":Distance",
         "//opencannabis/content:Name",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(

--- a/opencannabis/geo/Distance.proto
+++ b/opencannabis/geo/Distance.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.geo";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Enumeration of recognized units of distance.

--- a/opencannabis/geo/Geohash.proto
+++ b/opencannabis/geo/Geohash.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.geo";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/geo/Distance.proto";
 
 

--- a/opencannabis/geo/Location.proto
+++ b/opencannabis/geo/Location.proto
@@ -12,7 +12,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.geo";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/geo/Point.proto";
 import "opencannabis/geo/Address.proto";

--- a/opencannabis/geo/Point.proto
+++ b/opencannabis/geo/Point.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.geo";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/geo/Distance.proto";
 
 

--- a/opencannabis/inventory/BUILD.bazel
+++ b/opencannabis/inventory/BUILD.bazel
@@ -8,7 +8,7 @@ proto(
     name = "InventoryProduct",
     srcs = ["InventoryProduct.proto"],
     deps = [
-        "//opencannabis/core:Datamodel",
+        "@gust//gust/core:datamodel",
         "//opencannabis/base:ProductKey",
         "//opencannabis/temporal:Instant",
         "//opencannabis/commerce:Item",
@@ -21,7 +21,7 @@ proto(
     srcs = ["InventoryLocation.proto"],
     deps = [
         ":InventoryProduct",
-        "//opencannabis/core:Datamodel",
+        "@gust//gust/core:datamodel",
         "//opencannabis/contact:ContactInfo"],
 )
 

--- a/opencannabis/inventory/InventoryLocation.proto
+++ b/opencannabis/inventory/InventoryLocation.proto
@@ -12,7 +12,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.inventory";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/contact/ContactInfo.proto";
 import "opencannabis/inventory/InventoryProduct.proto";
 

--- a/opencannabis/inventory/InventoryProduct.proto
+++ b/opencannabis/inventory/InventoryProduct.proto
@@ -13,7 +13,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.inventory";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/base/ProductKey.proto";
 import "opencannabis/temporal/Instant.proto";

--- a/opencannabis/inventory/rfid/BUILD.bazel
+++ b/opencannabis/inventory/rfid/BUILD.bazel
@@ -8,7 +8,7 @@ proto(
     name = "RFID",
     srcs = ["RFID.proto"],
     deps = [
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -17,7 +17,7 @@ proto(
     deps = [
         ":RFID",
         "//opencannabis/temporal:Instant",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/inventory/rfid/LLRP.proto
+++ b/opencannabis/inventory/rfid/LLRP.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.inventory";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/temporal/Instant.proto";
 import "opencannabis/inventory/rfid/RFID.proto";
 

--- a/opencannabis/inventory/rfid/RFID.proto
+++ b/opencannabis/inventory/rfid/RFID.proto
@@ -12,7 +12,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.inventory";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Describes known vendors of RFID reader equipment.

--- a/opencannabis/media/BUILD.bazel
+++ b/opencannabis/media/BUILD.bazel
@@ -7,13 +7,13 @@ load("//defs:proto.bzl", "proto", "module")
 proto(
     name = "MediaOrientation",
     srcs = ["MediaOrientation.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "MediaType",
     srcs = ["MediaType.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -21,7 +21,7 @@ proto(
     srcs = ["MediaKey.proto"],
     deps = [
         ":MediaType",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -32,7 +32,7 @@ proto(
         ":MediaType",
         "//opencannabis/base:ProductKey",
         "//opencannabis/temporal:Instant",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/media/MediaItem.proto
+++ b/opencannabis/media/MediaItem.proto
@@ -13,7 +13,7 @@ option java_package = "io.opencannabis.schema.media";
 option java_multiple_files = false;
 option java_outer_classname = "AttachedMedia";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/media/MediaKey.proto";
 import "opencannabis/media/MediaType.proto";

--- a/opencannabis/media/MediaKey.proto
+++ b/opencannabis/media/MediaKey.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.media";
 option java_multiple_files = false;
 option java_outer_classname = "MediaItemKey";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/media/MediaType.proto";
 
 

--- a/opencannabis/media/MediaType.proto
+++ b/opencannabis/media/MediaType.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.media";
 option java_multiple_files = false;
 option java_outer_classname = "MediaItemType";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Specifies the type of media being attached or described.

--- a/opencannabis/person/BUILD.bazel
+++ b/opencannabis/person/BUILD.bazel
@@ -7,7 +7,7 @@ load("//defs:proto.bzl", "proto", "module")
 proto(
     name = "PersonName",
     srcs = ["PersonName.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -17,7 +17,7 @@ proto(
         ":PersonName",
         "//opencannabis/contact:ContactInfo",
         "//opencannabis/temporal:Date",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/person/Person.proto
+++ b/opencannabis/person/Person.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.person";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/temporal/Date.proto";
 import "opencannabis/contact/ContactInfo.proto";

--- a/opencannabis/person/PersonName.proto
+++ b/opencannabis/person/PersonName.proto
@@ -11,7 +11,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.person";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Represents a human being's name, in the style of "given" name (first) and "family" name (last) being concatenated to

--- a/opencannabis/products/BUILD.bazel
+++ b/opencannabis/products/BUILD.bazel
@@ -44,7 +44,7 @@ proto(
     name = "Flower",
     srcs = ["Flower.proto"],
     deps = [
-        "//opencannabis/core:Datamodel",
+        "@gust//gust/core:datamodel",
         "//opencannabis/base:ProductKey",
         "//opencannabis/content:MaterialsData",
         "//opencannabis/content:ProductContent"],
@@ -81,7 +81,7 @@ proto(
     srcs = ["SKU.proto"],
     deps = [
         "//opencannabis/commerce:Item",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/products/Flower.proto
+++ b/opencannabis/products/Flower.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.product";
 option java_multiple_files = false;
 option java_outer_classname = "FlowerProduct";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/base/ProductKey.proto";
 
 import "opencannabis/content/MaterialsData.proto";

--- a/opencannabis/products/SKU.proto
+++ b/opencannabis/products/SKU.proto
@@ -12,7 +12,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.sku";
 option java_multiple_files = false;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 import "opencannabis/commerce/Item.proto";
 
 

--- a/opencannabis/products/menu/BUILD.bazel
+++ b/opencannabis/products/menu/BUILD.bazel
@@ -17,7 +17,7 @@ proto(
     srcs = ["Menu.proto"],
     deps = [
         ":Section",
-        "//opencannabis/core:Datamodel",
+        "@gust//gust/core:datamodel",
         "//opencannabis/base:ProductKey",
         "//opencannabis/media:MediaKey",
         "//opencannabis/temporal:Instant",

--- a/opencannabis/products/menu/Menu.proto
+++ b/opencannabis/products/menu/Menu.proto
@@ -13,7 +13,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.menu";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 import "opencannabis/base/ProductKey.proto";
 import "opencannabis/media/MediaKey.proto";

--- a/opencannabis/structs/BUILD.bazel
+++ b/opencannabis/structs/BUILD.bazel
@@ -33,7 +33,7 @@ proto(
 proto(
     name = "Version",
     srcs = ["Version.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/structs/Version.proto
+++ b/opencannabis/structs/Version.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.struct";
 option java_multiple_files = true;
 option java_outer_classname = "Version";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Structure that allows universal specification of most common version patterns.

--- a/opencannabis/temporal/BUILD.bazel
+++ b/opencannabis/temporal/BUILD.bazel
@@ -7,25 +7,25 @@ load("//defs:proto.bzl", "proto", "module")
 proto(
     name = "Date",
     srcs = ["Date.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "Duration",
     srcs = ["Duration.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "Instant",
     srcs = ["Instant.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "Interval",
     srcs = ["Interval.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 proto(
@@ -40,13 +40,13 @@ proto(
         ":Time",
         ":Instant",
         ":Interval",
-        "//opencannabis/core:Datamodel"],
+        "@gust//gust/core:datamodel"],
 )
 
 proto(
     name = "Timehash",
     srcs = ["Timehash.proto"],
-    deps = ["//opencannabis/core:Datamodel"],
+    deps = ["@gust//gust/core:datamodel"],
 )
 
 

--- a/opencannabis/temporal/Date.proto
+++ b/opencannabis/temporal/Date.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.temporal";
 option java_multiple_files = false;
 option java_outer_classname = "TemporalDate";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Specifies a particular calendar date.

--- a/opencannabis/temporal/Instant.proto
+++ b/opencannabis/temporal/Instant.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.temporal";
 option java_multiple_files = false;
 option java_outer_classname = "TemporalInstant";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Specifies a particular moment in time.

--- a/opencannabis/temporal/Interval.proto
+++ b/opencannabis/temporal/Interval.proto
@@ -12,7 +12,7 @@ option java_package = "io.opencannabis.schema.temporal";
 option java_multiple_files = false;
 option java_outer_classname = "TemporalInterval";
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Enumerates supported time interval types.

--- a/opencannabis/temporal/Timehash.proto
+++ b/opencannabis/temporal/Timehash.proto
@@ -8,7 +8,7 @@ option objc_class_prefix = "OCS";
 option java_package = "io.opencannabis.schema.temporal";
 option java_multiple_files = true;
 
-import "opencannabis/core/Datamodel.proto";
+import "gust/core/datamodel.proto";
 
 
 // Specifies a point in temporal space, with the ability to zoom out by some amount by operating on substrings.

--- a/tools/copy.bara.sky
+++ b/tools/copy.bara.sky
@@ -1,0 +1,1 @@
+../copy.bara.sky


### PR DESCRIPTION
This changeset institutes a fix for the Gust model core, which the public Protocol sources are unaware of (besides as a prepack build toolchain).

To facilitate public export, private OCS protocol definitions now leverage the `gust.core` definitions directly. References to these definitions are rewritten as code exits the private spec border.